### PR TITLE
Add prototype to creeps for each action

### DIFF
--- a/src/prototypes/JavaScript/Creep/Freshly minted getActiveBodyparts accounting for boosts!.js
+++ b/src/prototypes/JavaScript/Creep/Freshly minted getActiveBodyparts accounting for boosts!.js
@@ -31,3 +31,46 @@ Creep.prototype.getBodypartsBoostEquivalent = function(type, action) {
   }
   return total;
 };
+
+//optional, add action+'Amount object to all creeps. For example creep.repairAmount would return the amount that creep can repair based on parts and boosts.
+//create an actionsMatrix to hold all actions based on body parts
+global.actionsMatrix = {
+    [WORK] : [
+        'harvest', 'build', 'repair','dismantle','upgradeController'
+    ],
+    [ATTACK] : [
+        'attack'
+    ], 
+    [RANGED_ATTACK] : [
+        'rangedAttack', 'rangedMassAttack'
+    ],
+    [HEAL] : [
+        'heal', 'rangedHeal'
+    ],
+    [CARRY] : [
+        'capacity'
+    ],
+    [MOVE] : [
+        'fatigue'
+    ],
+    [TOUGH] : [
+        'damage'
+    ]
+}
+//create a prototype for each action.
+for (const type in actionsMatrix) {
+    actionsMatrix[type].forEach(function(action){
+        Object.defineProperty(Creep.prototype, action+'Amount', {
+            get: function(){
+                //initialize..if one isn't initialized, none of them are
+                if (!this['_'+action+'Amount']) {
+                    this['_'+action+'Amount'] = this.getActiveBodypartsBoostEquivalent(type, action)
+                }
+                return this['_'+action+'Amount']
+            },
+            set: function(){},
+            enumerable: false,
+            configurable: true,
+        });
+    });
+}


### PR DESCRIPTION
Adds a prototype for each actions that calculates the amount it can perform this tick based on number of parts and boosts.  (example: creep.repairAmount for the amount a creep can repair, or creep.attackAmount for melee attack amount)